### PR TITLE
Factor out transport

### DIFF
--- a/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/MetadataParser.java
+++ b/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/MetadataParser.java
@@ -8,7 +8,11 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
+import org.sonatype.nexus.configuration.application.ApplicationDirectories;
 import org.sonatype.nexus.proxy.item.AbstractContentLocator;
 import org.sonatype.nexus.proxy.item.ContentLocator;
 import org.sonatype.nexus.proxy.item.StringContentLocator;
@@ -22,6 +26,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -36,6 +41,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Metadata parser and producer component, parses out of "raw" (streamed or not) source to entities and other way
  * around.
  */
+@Singleton
+@Named
 public class MetadataParser
     extends ComponentSupport
 {
@@ -43,9 +50,19 @@ public class MetadataParser
 
   private final ObjectMapper objectMapper;
 
+  @Inject
+  public MetadataParser(final ApplicationDirectories applicationDirectories) {
+    this(applicationDirectories.getTemporaryDirectory());
+  }
+
+  @VisibleForTesting
   public MetadataParser(final File temporaryDirectory) {
     this.temporaryDirectory = checkNotNull(temporaryDirectory);
     this.objectMapper = new ObjectMapper(); // this parses registry JSON
+  }
+
+  public File getTemporaryDirectory() {
+    return temporaryDirectory;
   }
 
   // Parse API

--- a/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/MetadataServiceFactoryImpl.java
+++ b/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/MetadataServiceFactoryImpl.java
@@ -31,26 +31,21 @@ public class MetadataServiceFactoryImpl
 
   private final MetadataParser metadataParser;
 
-  private final ProxyMetadataTransport httpProxyMetadataTransport;
+  private final ProxyMetadataTransport proxyMetadataTransport;
 
   @Inject
   public MetadataServiceFactoryImpl(final MetadataStore metadataStore,
                                     final MetadataParser metadataParser,
-                                    final ProxyMetadataTransport httpProxyMetadataTransport)
+                                    final ProxyMetadataTransport proxyMetadataTransport)
   {
     this.metadataStore = checkNotNull(metadataStore);
     this.metadataParser = checkNotNull(metadataParser);
-    this.httpProxyMetadataTransport = checkNotNull(httpProxyMetadataTransport);
-  }
-
-  @VisibleForTesting
-  public MetadataParser getMetadataParser() {
-    return metadataParser;
+    this.proxyMetadataTransport = checkNotNull(proxyMetadataTransport);
   }
 
   @VisibleForTesting
   public ProxyMetadataTransport getProxyMetadataTransport() {
-    return httpProxyMetadataTransport;
+    return proxyMetadataTransport;
   }
 
   @VisibleForTesting

--- a/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/ProxyMetadataTransport.java
+++ b/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/ProxyMetadataTransport.java
@@ -1,0 +1,24 @@
+package com.bolyuba.nexus.plugin.npm.metadata.internal;
+
+import java.io.IOException;
+
+import com.bolyuba.nexus.plugin.npm.metadata.PackageRoot;
+import com.bolyuba.nexus.plugin.npm.proxy.NpmProxyRepository;
+
+/**
+ * Transport for NPM Metadata.
+ */
+public interface ProxyMetadataTransport
+{
+  /**
+   * Fetches remote registry root of the proxied {@link NpmProxyRepository}. The returned iterator MUST BE handled as
+   * resource, as it incrementally parsing a potentially huge JSON document!
+   */
+  PackageRootIterator fetchRegistryRoot(final NpmProxyRepository npmProxyRepository) throws IOException;
+
+  /**
+   * Fetches one single package root of the proxied {@link NpmProxyRepository}.
+   */
+  PackageRoot fetchPackageRoot(final NpmProxyRepository npmProxyRepository, final String packageName,
+                               final PackageRoot expired) throws IOException;
+}

--- a/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/proxy/HttpProxyMetadataTransport.java
+++ b/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/metadata/internal/proxy/HttpProxyMetadataTransport.java
@@ -1,0 +1,161 @@
+package com.bolyuba.nexus.plugin.npm.metadata.internal.proxy;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.proxy.item.ContentLocator;
+import org.sonatype.nexus.proxy.item.FileContentLocator;
+import org.sonatype.nexus.proxy.item.PreparedContentLocator;
+import org.sonatype.nexus.proxy.storage.remote.httpclient.HttpClientManager;
+import org.sonatype.sisu.goodies.common.ComponentSupport;
+
+import com.bolyuba.nexus.plugin.npm.NpmRepository;
+import com.bolyuba.nexus.plugin.npm.metadata.PackageRoot;
+import com.bolyuba.nexus.plugin.npm.metadata.internal.MetadataParser;
+import com.bolyuba.nexus.plugin.npm.metadata.internal.PackageRootIterator;
+import com.bolyuba.nexus.plugin.npm.metadata.internal.ProxyMetadataTransport;
+import com.bolyuba.nexus.plugin.npm.proxy.NpmProxyRepository;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link ProxyMetadataTransport} for HTTP.
+ */
+@Singleton
+@Named
+public class HttpProxyMetadataTransport
+    extends ComponentSupport
+    implements ProxyMetadataTransport
+{
+  private static final Logger outboundRequestLog = LoggerFactory.getLogger("remote.storage.outbound");
+
+  private static final String PROP_ETAG = "remote.etag";
+
+  private final MetadataParser metadataParser;
+
+  private final HttpClientManager httpClientManager;
+
+  @Inject
+  public HttpProxyMetadataTransport(final MetadataParser metadataParser,
+                                    final HttpClientManager httpClientManager)
+  {
+    this.metadataParser = checkNotNull(metadataParser);
+    this.httpClientManager = checkNotNull(httpClientManager);
+  }
+
+  /**
+   * Performs a HTTP GET to fetch the registry root. Note: by testing on my mac (MBP 2012 SSD), seems OrientDB is
+   * "slow"
+   * to consume the streamed HTTP response (ie. to push it immediately into database, maintaining indexes etc). Hence,
+   * we save the response JSON to temp file and parse it from there to not have remote registry HTTP Server give up
+   * on connection with us.
+   */
+  @Override
+  public PackageRootIterator fetchRegistryRoot(final NpmProxyRepository npmProxyRepository) throws IOException {
+    final HttpClient httpClient = httpClientManager.create(npmProxyRepository,
+        npmProxyRepository.getRemoteStorageContext());
+    try {
+      final HttpGet get = new HttpGet(
+          buildUri(npmProxyRepository, "-/all")); // TODO: this in NPM specific, might try both root and NPM api
+      // TODO: during devel INFO, should be DEBUG
+      outboundRequestLog.info("{} - NPM GET {}", npmProxyRepository.getId(), get.getURI());
+      get.addHeader("accept", NpmRepository.JSON_MIME_TYPE);
+      final HttpResponse httpResponse = httpClient.execute(get);
+      try {
+        // TODO: during devel INFO, should be DEBUG
+        outboundRequestLog.info("{} - NPM GET {} - {}", npmProxyRepository.getId(), get.getURI(),
+            httpResponse.getStatusLine());
+        if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+          final File tempFile = File
+              .createTempFile(npmProxyRepository.getId() + "-root", "temp.json", metadataParser.getTemporaryDirectory());
+          try (final BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(tempFile))) {
+            httpResponse.getEntity().writeTo(bos);
+            bos.flush();
+          }
+          final FileContentLocator cl = new FileContentLocator(tempFile, NpmRepository.JSON_MIME_TYPE, true);
+          return metadataParser.parseRegistryRoot(npmProxyRepository.getId(), cl);
+        }
+        throw new IOException("Unexpected response from registry root " + httpResponse.getStatusLine());
+      }
+      finally {
+        EntityUtils.consumeQuietly(httpResponse.getEntity());
+      }
+    }
+    finally {
+      httpClientManager.release(npmProxyRepository, npmProxyRepository.getRemoteStorageContext());
+    }
+  }
+
+  /**
+   * Performs a conditional GET to fetch the package root and returns the fetched package root. If fetch succeeded
+   * (HTTP 200 Ok is returned), the package root is also pushed into {@code MetadataStore}. In short, the returned
+   * package root from this method is guaranteed to be present in the store too.
+   */
+  @Override
+  public PackageRoot fetchPackageRoot(final NpmProxyRepository npmProxyRepository, final String packageName,
+                                      final PackageRoot expired) throws IOException
+  {
+    final HttpClient httpClient = httpClientManager.create(npmProxyRepository,
+        npmProxyRepository.getRemoteStorageContext());
+    try {
+      final HttpGet get = new HttpGet(buildUri(npmProxyRepository, packageName));
+      // TODO: during devel INFO, should be DEBUG
+      outboundRequestLog.info("{} - NPM GET {}", npmProxyRepository.getId(), get.getURI());
+      get.addHeader("accept", NpmRepository.JSON_MIME_TYPE);
+      if (expired != null && expired.getProperties().containsKey(PROP_ETAG)) {
+        get.addHeader("if-none-match", expired.getProperties().get(PROP_ETAG));
+      }
+      final HttpResponse httpResponse = httpClient.execute(get);
+      try {
+        // TODO: during devel INFO, should be DEBUG
+        outboundRequestLog.info("{} - NPM GET {} - {}", npmProxyRepository.getId(), get.getURI(),
+            httpResponse.getStatusLine());
+        if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_MODIFIED) {
+          return expired;
+        }
+        if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+          final PreparedContentLocator pcl = new PreparedContentLocator(httpResponse.getEntity().getContent(),
+              NpmRepository.JSON_MIME_TYPE, ContentLocator.UNKNOWN_LENGTH);
+          final PackageRoot fresh = metadataParser.parsePackageRoot(npmProxyRepository.getId(), pcl);
+          if (httpResponse.containsHeader("etag")) {
+            fresh.getProperties().put(PROP_ETAG, httpResponse.getFirstHeader("etag").getValue());
+          }
+          return fresh;
+        }
+        return null;
+      }
+      finally {
+        EntityUtils.consumeQuietly(httpResponse.getEntity());
+      }
+    }
+    finally {
+      httpClientManager.release(npmProxyRepository, npmProxyRepository.getRemoteStorageContext());
+    }
+  }
+
+  /**
+   * Builds and return registry URI for given package name.
+   */
+  private String buildUri(final NpmProxyRepository npmProxyRepository, final String pathElem) {
+    final String registryUrl = npmProxyRepository.getRemoteUrl();
+    if (registryUrl.endsWith("/")) {
+      return registryUrl + pathElem;
+    }
+    else {
+      return registryUrl + "/" + pathElem;
+    }
+  }
+}


### PR DESCRIPTION
Refactor: moved out transport from proxy md service to simplify it,
and be able to  make UTs faster by customising it to NOT harrass 
registry root.

Also, metadata parser became a managed singleton now.
