### PR TITLE
NEXUS-6754: Use "NPM" for provider name

### DIFF
--- a/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/templates/NpmRepositoryTemplateProvider.java
+++ b/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/templates/NpmRepositoryTemplateProvider.java
@@ -21,7 +21,7 @@ public class NpmRepositoryTemplateProvider extends AbstractRepositoryTemplatePro
 
     private static final String NPM_GROUP = "npm_group";
 
-    public static final String NPM_PROVIDER = "Npm plugin";
+    public static final String NPM_PROVIDER = "NPM";
 
     @Override
     public TemplateSet getTemplates() {


### PR DESCRIPTION
To have it aligned with other plugin provided
repositories.
